### PR TITLE
Upgrade python version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/python:3.6.0-alpine
+FROM library/python:3.6-alpine
 MAINTAINER Joan Font <joanfont@gmail.com>
 
 RUN apk add --update build-base \


### PR DESCRIPTION
Due to some errors I got with dependencies in python3.6.0 (contextvars), I suggest to you to upgrade the Python version image, to allow patch upgrades in your docker image 